### PR TITLE
fix: yarn doc

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -20,7 +20,7 @@ module.exports = {
     {
       name: 'Demo',
       sections: glob
-        .sync('docs/*.md')
+        .sync('docs-md/*.md')
         .map((p) => ({ name: path.basename(p, '.md'), content: p })),
     },
   ],


### PR DESCRIPTION
## Why
更改 md 目录时遗漏 styleguide 配置了

## Test
![image](https://user-images.githubusercontent.com/19591950/87124219-edf23300-c2ba-11ea-9fd7-8e14f49a60e8.png)
