### PR TITLE
fix: 暂时移除 esm 模块的导出

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -104,6 +104,7 @@ yarn dev
 - 修复更改 rowH 时未改变树节点高度的问题
 - 支持进度修改功能
 - 支持修改里程碑完成状态
+- 修复使用 rollup 打包时，<gantt-group> 组件丢失对 <gantt-layout> 的引用的问题
 
 [⬆ Back to Top](#table-of-contents)
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ yarn dev
 - fix 'rowH' doesn't inpact tree nodes
 - support drag to change progress
 - support click to toggle milestone
+- lost <gantt-layout> in <gantt-group> when compile with rollup
 
 [⬆ Back to Top](#table-of-contents)
 
@@ -152,6 +153,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "dist"
   ],
   "main": "dist/v-gantt.umd.min.js",
-  "module": "dist/v-gantt.esm.min.js",
   "unpkg": "dist/v-gantt.umd.min.js",
   "browser": {
     "./sfc": "src/index.vue"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,6 +3,7 @@
  * 建议优先使用 webpack 打包的代码（体积更小，vue-cli 有细致的优化）
  * rollup 可以作为产出 esm 模块的补充
  */
+// FIXME: 目前用 rollup 打包会导致 gantt-group 组件丢失对 gantt-layout 组件的引用！
 
 // 相比 @rollup/plugin-typescript，解决了引入虚拟模块的问题
 // https://github.com/ezolenko/rollup-plugin-typescript2/issues/78#issuecomment-399524537


### PR DESCRIPTION
## Why
在项目中，模块打包器如 webpack & rollup 会优先使用 package 中的 module 文件；但目前 rollup 配置会导致打包后 `<gantt-group>` 组件丢失对 `<gantt-layout>` 组件的异步引用！
```ts
export default Vue.extend({
  name: 'GanttGroup',
  components: {
    GanttProgress,
    GanttLayout: () => import('./gantt-layout.vue'),
  },
}
```

## How
1. 记录问题到 README
2. 移除 package.json 中的 module 字段
