### PR TITLE
style: 调整里程碑位置及周历数字位置

### DIFF
--- a/src/components/gantt-chart.vue
+++ b/src/components/gantt-chart.vue
@@ -591,7 +591,7 @@ export default Vue.extend({
             .milestone-line {
               position: absolute;
               top: calc(100% + 1px);
-              left: calc(50% - 1px);
+              left: calc(100% - 1px);
               width: 2px;
               height: 10000px;
               background-color: fade(@progress-background, 50%);
@@ -617,9 +617,11 @@ export default Vue.extend({
           }
 
           .date-in-month {
+            @offset: 4px;
+
             position: absolute;
-            top: 0;
-            right: 1px;
+            top: @offset / 2;
+            right: @offset;
             transform: scale(0.55);
             transform-origin: 100% 0;
             line-height: 1;

--- a/src/components/gantt-milestone.vue
+++ b/src/components/gantt-milestone.vue
@@ -36,6 +36,14 @@ export default Vue.extend({
   display: flex;
   align-items: center;
   justify-content: center;
+  cursor: grab;
+
+  &.moving,
+  &.focusing {
+    &::before {
+      display: none;
+    }
+  }
 
   .content {
     width: 16px;

--- a/src/components/gantt-node.vue
+++ b/src/components/gantt-node.vue
@@ -63,7 +63,7 @@ export default Vue.extend({
       const { rowH, colW } = this.bus
       const { x, y, w, h } = this.data
       const { dragData, resizeData } = this
-      // 里程碑中心需要对齐每天最右边，而非中间
+      // 里程碑中心需要对齐当天最右边，而非中间
       const milestoneOffset = isMilestone(this.data) ? colW / 2 : 0
 
       return {

--- a/src/components/gantt-node.vue
+++ b/src/components/gantt-node.vue
@@ -63,8 +63,11 @@ export default Vue.extend({
       const { rowH, colW } = this.bus
       const { x, y, w, h } = this.data
       const { dragData, resizeData } = this
+      // 里程碑中心需要对齐每天最右边，而非中间
+      const milestoneOffset = isMilestone(this.data) ? colW / 2 : 0
+
       return {
-        x: x * colW + dragData.offsetX,
+        x: x * colW + dragData.offsetX + milestoneOffset,
         y: y * rowH,
         w: Math.max(colW, w * colW + resizeData.offsetX),
         h: h * rowH,


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

## Why
1. 里程碑现在位置在当日正中间，应该是在当日最右边
2. 周历上的数字太接近右上角，需要留一些间距

## How
对于里程碑的情况，增加偏移量即可
```javascript
// ....
// 里程碑中心需要对齐当天最右边，而非中间
const milestoneOffset = isMilestone(this.data) ? colW / 2 : 0
return {
        x: x * colW + dragData.offsetX + milestoneOffset,
        //...
}
```

改下样式即可增加间距
```less
.date-in-month {
      @offset: 4px;
      position: absolute;	           
      top: @offset / 2;
      right: @offset;
}
```
